### PR TITLE
Fix Swift Package build which pulls libgit2 1.9.1 instead of libgit2 …

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ibrahimcetin/libgit2.git", from: "1.8.0"),
+        .package(url: "https://github.com/ibrahimcetin/libgit2.git", exact: "1.8.0"),
         .package(url: "https://github.com/realm/SwiftLint.git", from: "0.54.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.53.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0")


### PR DESCRIPTION
…1.8.0